### PR TITLE
feat(#3): Google Maps BaseMap 컴포넌트

### DIFF
--- a/src/components/google/BaseMap.tsx
+++ b/src/components/google/BaseMap.tsx
@@ -1,0 +1,60 @@
+import React, { useCallback, useMemo, useRef } from "react";
+import { googleMapAtom } from "../../stores/atoms";
+import { useSetAtom } from "jotai";
+import { GoogleMap } from "@react-google-maps/api";
+import { GOOGLE_MAPS } from "../../constants/googleMaps";
+
+interface Props extends Omit<GoogleMap["props"], "onLoad" | "onUnmount"> {
+  onLoadCallback?: (map: google.maps.Map) => void;
+  onUnmountCallback?:
+    | ((map: google.maps.Map) => void | Promise<void>)
+    | undefined;
+}
+
+function BaseMap(props: Props) {
+  const {
+    mapContainerStyle = GOOGLE_MAPS.defaultMapContainerStyle,
+    options = GOOGLE_MAPS.defaultOptions,
+    onLoadCallback,
+    onUnmountCallback,
+    center,
+    ...rest
+  } = props;
+  const setGoogleMap = useSetAtom(googleMapAtom);
+  const cacheCenter = useMemo(() => center, [center]);
+
+  const callbackRef = useRef({
+    onLoadCallbackRef: onLoadCallback,
+    onUnmountCallbackRef: onUnmountCallback,
+  });
+
+  const onLoadFn = useCallback(
+    function callback(map: google.maps.Map) {
+      setGoogleMap(map);
+
+      callbackRef.current.onLoadCallbackRef?.(map);
+    },
+    [setGoogleMap]
+  );
+
+  const onUnmountFn = useCallback(
+    function callback(map: google.maps.Map) {
+      setGoogleMap(null);
+      callbackRef.current.onUnmountCallbackRef?.(map);
+    },
+    [setGoogleMap]
+  );
+
+  return (
+    <GoogleMap
+      mapContainerStyle={mapContainerStyle}
+      options={options}
+      {...(cacheCenter && { center: cacheCenter })}
+      onLoad={onLoadFn}
+      onUnmount={onUnmountFn}
+      {...rest}
+    ></GoogleMap>
+  );
+}
+
+export default BaseMap;

--- a/src/constants/googleMaps.ts
+++ b/src/constants/googleMaps.ts
@@ -1,0 +1,22 @@
+const defaultMapContainerStyle: React.CSSProperties = {
+  width: "100vh",
+  height: "100vh",
+};
+
+const defaultOptions: google.maps.MapOptions = {
+  disableDefaultUI: true,
+  styles: [
+    {
+      featureType: "poi",
+      elementType: "labels.icon",
+      stylers: [{ visibility: "off" }],
+    },
+    {
+      featureType: "landscape",
+      elementType: "labels",
+      stylers: [{ visibility: "off" }],
+    },
+  ],
+};
+
+export const GOOGLE_MAPS = { defaultMapContainerStyle, defaultOptions };

--- a/src/layout/index.tsx
+++ b/src/layout/index.tsx
@@ -17,7 +17,10 @@ function Layout() {
                   component={RouteLink}
                   to={item.toLocaleLowerCase().replace(" ", "-")}
                   key={item}
-                  sx={{ color: "#fff", pr: 5 }}
+                  sx={{
+                    color: "#fff",
+                    pr: 5,
+                  }}
                 >
                   {item}
                 </Link>

--- a/src/pages/google-map.tsx
+++ b/src/pages/google-map.tsx
@@ -1,7 +1,34 @@
-import React from "react";
+import React, { useCallback, useState } from "react";
+import BaseMap from "../components/google/BaseMap";
+import { useJsApiLoader } from "@react-google-maps/api";
+import { useCurrentLocation } from "../hooks/useCurrentLocation";
 
 function GoogleMap() {
-  return <div>GoogleMap</div>;
+  const [center, setCenter] = useState<google.maps.LatLngLiteral>({
+    lat: 35.1795543,
+    lng: 129.0756416,
+  });
+  const { isLoaded } = useJsApiLoader({
+    id: "google-map-script",
+    googleMapsApiKey: import.meta.env.VITE_GOOGLE_MAPS_API_KEY,
+    language: "ko",
+  });
+
+  useCurrentLocation(
+    useCallback(({ lat, lng }) => {
+      setCenter({ lat, lng });
+    }, [])
+  );
+
+  return (
+    <>
+      {isLoaded ? (
+        <BaseMap zoom={13} center={center} onClick={console.log} />
+      ) : (
+        <div>loading... 🚀</div>
+      )}
+    </>
+  );
 }
 
 export default GoogleMap;

--- a/src/stores/atoms/index.ts
+++ b/src/stores/atoms/index.ts
@@ -1,0 +1,7 @@
+import { atom } from "jotai";
+import "@react-google-maps/api";
+
+export const googleMapAtom = atom<google.maps.Map | null>(null);
+export const googleMarkersAtom = atom<{
+  [key: string]: google.maps.Marker;
+}>({});


### PR DESCRIPTION
- @react-google-maps/api
- 추상화 BaseMap 컴포넌트(모든 옵션 수용)
- jotai를 사용하여 Map 객체를 전역 상태로 사용할 수 있도록 해보자